### PR TITLE
refactor: comment system

### DIFF
--- a/example-config.toml
+++ b/example-config.toml
@@ -6,14 +6,13 @@ languageCode = "en"
 hasCJKLanguage = true
 defaultContentLanguage = "en"
 
+theme = "neonote"
+
 enableRobotsTXT = true
-[pagination]
-  pagerSize = 7  # number of articles per page
 enableEmoji = true
 
-# Enable Disqus
-# [config.services.disqus]
-#   shortname = "2kabhishek"
+[pagination]
+  pagerSize = 7  # number of articles per page
 
 [module]
   [[module.imports]]
@@ -34,8 +33,27 @@ enableEmoji = true
 [params.assets]
   css = ["css/fonts.css", "css/custom.css"]
 
-[params.comments]
-  enable = false  # En/Disable comments, You can also enable comments on per page.
+[params.global_comments]
+  enable = true     # En/Disable comments, You can also enable comments on per page.
+  comment_system = "disqus" # or giscus, utterances
+
+# Configure the appropriate setting based on the comment system you choose
+[params.disqus]
+  shortname = "2kabhishek"
+
+[params.giscus]
+  repo = "2kabhishek/neonote"
+  repoID = "some-repo-id"
+  category = "Announcements"
+  categoryID = "some-category-id"
+  dataTheme = "dark"
+  dataLang = "en"
+
+[params.utterances]
+  repo = "2kabhishek/neonote"
+  issueTerm = "pathname"
+  theme = "preferred-color-scheme"
+  crossorigin = "anonymous"
 
 [params.math]
   enable = false # Load math globally, You can also enable math on per page.

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -10,10 +10,6 @@ hasCJKLanguage = true
 
 enableRobotsTXT = true
 
-# Enable Disqus
-[config.services.disqus]
-  shortname = "2kabhishek"
-
 [markup.highlight]
   codeFences = true
   guessSyntax = true
@@ -48,15 +44,17 @@ enableRobotsTXT = true
 ShowOutdatedOnPosts = true  # Add a prompt box before a post if the post published long ago
 OutdatedDays = 730  # Collaborate with preceding params. If a post is edited before this params, a prompt box will appear before the post
 
-# Disqus comments system
-[params.comments]
-  enable = false  # En/Disable comments globally, default: false. You can always enable comments on per page.
-
-# Another comments system that using github discussion. See detail in https://giscus.app
-# Conflict with Disqus
 # TODO: auto change light/dark theme when the whole site is setting auto-theme
+
+[params.global_comments]
+  enable = true     # comment system switch
+  comment_system = "disqus" # or giscus, utterances
+
+# Configure the appropriate setting based on the comment system you choose
+[params.disqus]
+  shortname = "2kabhishek"
+
 [params.giscus]
-  enable = true
   repo = "2kabhishek/neonote"
   repoID = "some-repo-id"
   category = "Announcements"
@@ -65,7 +63,6 @@ OutdatedDays = 730  # Collaborate with preceding params. If a post is edited bef
   dataLang = "en"
 
 [params.utterances]
-  enable = true
   repo = "2kabhishek/neonote"
   issueTerm = "pathname"
   theme = "preferred-color-scheme"

--- a/layouts/partials/article-comments.html
+++ b/layouts/partials/article-comments.html
@@ -1,29 +1,35 @@
-{{- if or (eq .Params.utterances true) (and (ne .Params.utterances false) (eq .Site.Params.utterances.enable true)) -}}
-<script src="https://utteranc.es/client.js"
-        repo="{{ .Site.Params.utterances.repo }}"
-        issue-term="{{ .Site.Params.utterances.issueTerm }}"
-        theme="{{ .Site.Params.utterances.theme }}"
-        crossorigin="anonymous"
-        async>
-</script>
-{{- else if gt (len .Site.Config.Services.Disqus.Shortname) 0 -}}
-    {{- if or (eq .Params.comments true) (and (ne .Params.comments false) (eq .Site.Params.comments.enable true)) -}}
-        <section class="article-discussion">
-            {{- template "_internal/disqus.html" . -}}
-        </section>
-    {{- end -}}
-{{- else if or (eq .Params.giscus true) (and (ne .Params.giscus false) (eq .Site.Params.giscus.enable true)) -}}
-<script src="https://giscus.app/client.js"
-        data-repo={{ .Site.Params.giscus.repo }}
-        data-repo-id={{ .Site.Params.giscus.repoID }}
-        data-category={{ .Site.Params.giscus.category }}
-        data-category-id={{ .Site.Params.giscus.categoryID }}
-        data-mapping="title"
-        data-reactions-enabled="1"
-        data-emit-metadata="0"
-        data-theme={{ .Site.Params.giscus.dataTheme }}
-        data-lang={{ .Site.Params.giscus.dataLang }}
-        crossorigin="anonymous"
-        async>
-</script>
-{{- end -}}
+{{- $globalComments := .Site.Params.global_comments.enable | default false -}}
+{{- $pageComments := .Params.comments | default true -}}
+{{- $system := .Site.Params.global_comments.comment_system | default "" -}}
+
+{{- if and $globalComments $pageComments }}
+    <section class="article-discussion">
+        {{- if eq $system "disqus" }}
+            {{- if .Site.Params.disqus.shortname }}
+                {{- template "_internal/disqus.html" . -}}
+            {{- end }}
+        {{- else if eq $system "giscus" }}
+        <script src="https://giscus.app/client.js"
+                data-repo={{ .Site.Params.giscus.repo }}
+                data-repo-id={{ .Site.Params.giscus.repoID }}
+                data-category={{ .Site.Params.giscus.category }}
+                data-category-id={{ .Site.Params.giscus.categoryID }}
+                data-mapping="title"
+                data-reactions-enabled="1"
+                data-emit-metadata="0"
+                data-theme={{ .Site.Params.giscus.dataTheme }}
+                data-lang={{ .Site.Params.giscus.dataLang }}
+                crossorigin="anonymous"
+                async>
+        </script>
+        {{- else if eq $system "utterances" }}
+        <script src="https://utteranc.es/client.js"
+                repo={{ .Site.Params.utterances.repo }}
+                issue-term={{ .Site.Params.utterances.issueTerm }}
+                theme={{ .Site.Params.utterances.theme }}
+                crossorigin="anonymous"
+                async>
+        </script>
+        {{- end }}
+    </section>
+{{- end}}


### PR DESCRIPTION
## What does the PR do? (Required)
**Refactor comment system**
> Why it is necessary?
> The `[params.comments]` in the `hugo.toml/config.toml` is misleading to control the Disqus comment system
- [x] Use `[params.comments]` as the global switch to control the comment system 
- [x] Use similar option structure to specify the chosed one from `[params.disqus]/[params.giscus]/[params.utterances]`
- [x] provide page granularity comment system configuration in front matter

Simply put, first check the [params.comments] setting in config.toml.
- If it is false, no comment system will be enabled for any page.
- If it is true, then check the `comments` option in the page's front matter; 
     - if it is false, the comment system will not be shown on that page.
     - if it is omitted, the default value is true.

Additionally, you can choose different comment systems for different posts.
Set `[params.disqus]`, `[params.giscus]`,  and `[params.utterances]` all to false in `config.toml` to disable them globally,
then configure the desired system for each post individually in its front matter.
```text
+++
...
comments = true # this is not necessary, cause it's default value is true
[utterances]
    enable = true
+++
```
`post2` front matter:
```text
+++
...
comments = true
[giscus]]
    enable = true
+++
```
 
## Checklist (Required)

- [x] I have tested the changes on my local machine partly
- [ ] I have added relevant documentation and tests for the changes
- [x] I have followed the style guidelines of this project

## Evidence (Required)
<img width="400" height="300" alt="Screenshot from 2025-09-11 00-04-43" src="https://github.com/user-attachments/assets/cbd382f0-79e8-4bd0-8677-5dd7387eedf9" />
<img width="400" height="300" alt="Screenshot from 2025-09-11 00-05-14" src="https://github.com/user-attachments/assets/973199a8-d3f5-4042-b9fc-04dddc7b452e" />

Cause i don't have Disqus accout, more test need to be checked on Disqus.
