### PR TITLE
refactor: comment system

### DIFF
--- a/example-config.toml
+++ b/example-config.toml
@@ -6,14 +6,13 @@ languageCode = "en"
 hasCJKLanguage = true
 defaultContentLanguage = "en"
 
+theme = "neonote"
+
 enableRobotsTXT = true
-[pagination]
-  pagerSize = 7  # number of articles per page
 enableEmoji = true
 
-# Enable Disqus
-# [config.services.disqus]
-#   shortname = "2kabhishek"
+[pagination]
+  pagerSize = 7  # number of articles per page
 
 [module]
   [[module.imports]]
@@ -34,8 +33,27 @@ enableEmoji = true
 [params.assets]
   css = ["css/fonts.css", "css/custom.css"]
 
-[params.comments]
-  enable = false  # En/Disable comments, You can also enable comments on per page.
+[params.global_comments]
+  enable = true     # En/Disable comments, You can also enable comments on per page.
+  comment_system = "disqus" # or giscus, utterances
+
+# Configure the appropriate setting based on the comment system you choose
+[params.disqus]
+  shortname = "2kabhishek"
+
+[params.giscus]
+  repo = "2kabhishek/neonote"
+  repoID = "some-repo-id"
+  category = "Announcements"
+  categoryID = "some-category-id"
+  dataTheme = "dark"
+  dataLang = "en"
+
+[params.utterances]
+  repo = "2kabhishek/neonote"
+  issueTerm = "pathname"
+  theme = "preferred-color-scheme"
+  crossorigin = "anonymous"
 
 [params.math]
   enable = false # Load math globally, You can also enable math on per page.

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -10,10 +10,6 @@ hasCJKLanguage = true
 
 enableRobotsTXT = true
 
-# Enable Disqus
-[config.services.disqus]
-  shortname = "2kabhishek"
-
 [markup.highlight]
   codeFences = true
   guessSyntax = true
@@ -48,15 +44,17 @@ enableRobotsTXT = true
 ShowOutdatedOnPosts = true  # Add a prompt box before a post if the post published long ago
 OutdatedDays = 730  # Collaborate with preceding params. If a post is edited before this params, a prompt box will appear before the post
 
-# Disqus comments system
-[params.comments]
-  enable = false  # En/Disable comments globally, default: false. You can always enable comments on per page.
-
-# Another comments system that using github discussion. See detail in https://giscus.app
-# Conflict with Disqus
 # TODO: auto change light/dark theme when the whole site is setting auto-theme
+
+[params.global_comments]
+  enable = true     # comment system switch
+  comment_system = "disqus" # or giscus, utterances
+
+# Configure the appropriate setting based on the comment system you choose
+[params.disqus]
+  shortname = "2kabhishek"
+
 [params.giscus]
-  enable = true
   repo = "2kabhishek/neonote"
   repoID = "some-repo-id"
   category = "Announcements"
@@ -65,7 +63,6 @@ OutdatedDays = 730  # Collaborate with preceding params. If a post is edited bef
   dataLang = "en"
 
 [params.utterances]
-  enable = true
   repo = "2kabhishek/neonote"
   issueTerm = "pathname"
   theme = "preferred-color-scheme"

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -61,6 +61,7 @@ OutdatedDays = 730  # Collaborate with preceding params. If a post is edited bef
   categoryID = "some-category-id"
   dataTheme = "dark"
   dataLang = "en"
+  crossorigin = "anonymous"
 
 [params.utterances]
   repo = "2kabhishek/neonote"

--- a/exampleSite/content/about.md
+++ b/exampleSite/content/about.md
@@ -6,6 +6,7 @@ aliases = ["about-us","about-hugo","contact"]
 type = "about"
 layout = "about"
 hidden = true
+comments = false
 author = "Hugo Authors"
 +++
 

--- a/layouts/partials/article-comments.html
+++ b/layouts/partials/article-comments.html
@@ -9,7 +9,7 @@
                 {{- template "_internal/disqus.html" . -}}
             {{- end }}
         {{- else if eq $system "giscus" }}
-        <script src="https://giscus.app/client.js"
+            <script src="https://giscus.app/client.js"
                 data-repo={{ .Site.Params.giscus.repo }}
                 data-repo-id={{ .Site.Params.giscus.repoID }}
                 data-category={{ .Site.Params.giscus.category }}
@@ -19,17 +19,17 @@
                 data-emit-metadata="0"
                 data-theme={{ .Site.Params.giscus.dataTheme }}
                 data-lang={{ .Site.Params.giscus.dataLang }}
-                crossorigin="anonymous"
+				crossorigin={{ .Site.Params.giscus.crossorigin }}
                 async>
-        </script>
+            </script>
         {{- else if eq $system "utterances" }}
-        <script src="https://utteranc.es/client.js"
+            <script src="https://utteranc.es/client.js"
                 repo={{ .Site.Params.utterances.repo }}
                 issue-term={{ .Site.Params.utterances.issueTerm }}
                 theme={{ .Site.Params.utterances.theme }}
-                crossorigin="anonymous"
+                crossorigin={{ .Site.Params.utterances.crossorigin }}
                 async>
-        </script>
+            </script>
         {{- end }}
     </section>
 {{- end}}

--- a/layouts/partials/article-comments.html
+++ b/layouts/partials/article-comments.html
@@ -1,29 +1,35 @@
-{{- if or (eq .Params.utterances true) (and (ne .Params.utterances false) (eq .Site.Params.utterances.enable true)) -}}
-<script src="https://utteranc.es/client.js"
-        repo="{{ .Site.Params.utterances.repo }}"
-        issue-term="{{ .Site.Params.utterances.issueTerm }}"
-        theme="{{ .Site.Params.utterances.theme }}"
-        crossorigin="anonymous"
-        async>
-</script>
-{{- else if gt (len .Site.Config.Services.Disqus.Shortname) 0 -}}
-    {{- if or (eq .Params.comments true) (and (ne .Params.comments false) (eq .Site.Params.comments.enable true)) -}}
-        <section class="article-discussion">
-            {{- template "_internal/disqus.html" . -}}
-        </section>
-    {{- end -}}
-{{- else if or (eq .Params.giscus true) (and (ne .Params.giscus false) (eq .Site.Params.giscus.enable true)) -}}
-<script src="https://giscus.app/client.js"
-        data-repo={{ .Site.Params.giscus.repo }}
-        data-repo-id={{ .Site.Params.giscus.repoID }}
-        data-category={{ .Site.Params.giscus.category }}
-        data-category-id={{ .Site.Params.giscus.categoryID }}
-        data-mapping="title"
-        data-reactions-enabled="1"
-        data-emit-metadata="0"
-        data-theme={{ .Site.Params.giscus.dataTheme }}
-        data-lang={{ .Site.Params.giscus.dataLang }}
-        crossorigin="anonymous"
-        async>
-</script>
-{{- end -}}
+{{- $globalComments := .Site.Params.global_comments.enable | default false -}}
+{{- $pageComments := .Params.comments | default true -}}
+{{- $system := .Site.Params.global_comments.comment_system | default "" -}}
+
+{{- if and $globalComments $pageComments }}
+    <section class="article-discussion">
+        {{- if eq $system "disqus" }}
+            {{- if .Site.Params.disqus.shortname }}
+                {{- template "_internal/disqus.html" . -}}
+            {{- end }}
+        {{- else if eq $system "giscus" }}
+        <script src="https://giscus.app/client.js"
+                data-repo={{ .Site.Params.giscus.repo }}
+                data-repo-id={{ .Site.Params.giscus.repoID }}
+                data-category={{ .Site.Params.giscus.category }}
+                data-category-id={{ .Site.Params.giscus.categoryID }}
+                data-mapping="title"
+                data-reactions-enabled="1"
+                data-emit-metadata="0"
+                data-theme={{ .Site.Params.giscus.dataTheme }}
+                data-lang={{ .Site.Params.giscus.dataLang }}
+                crossorigin="anonymous"
+                async>
+        </script>
+        {{- else if eq $system "utterances" }}
+        <script src="https://utteranc.es/client.js"
+                repo={{ .Site.Params.utterances.repo }}
+                issue-term={{ .Site.Params.utterances.issueTerm }}
+                theme={{ .Site.Params.utterances.theme }}
+                crossorigin="anonymous"
+                async>
+        </script>
+        {{- end }}
+    </section>
+{{- end}}


### PR DESCRIPTION
## What does the PR do? (Required)
**Refactor comment system**
- [x] add global comment system selection (disqus, giscus, utterances)
- [x] support enable/disable comments per page via front matter
- [x] update example-config.toml

Finally, I found some time to complete this PR. 🙂

In this PR, A global switch to control the comment system (enable/disable, and choose which one to use) was introduced.

The idea of having a separate comment system for every post doesn’t make much sense — it’s redundant and unnecessary. However, controlling whether comments are enabled on a per-page basis is useful.

Per page comment control:
- `post1`
```
+++
...
comments = true  # this is default behaviour
+++
```
- `post2`
```
+++
...
comments = false # when we want to close the comments of a post, we need to set this explicitly 
+++
```
## Checklist (Required)

- [x] I have tested the changes on my local machine
- [x] I have added relevant documentation and tests for the changes
- [x] I have followed the style guidelines of this project

## Evidence (Required)
Result of `post1`
<img width="1321" height="1026" alt="test1" src="https://github.com/user-attachments/assets/a9e63691-cdbc-493d-955c-8c32a53d168e" />
Result of `post2` (the comment has been closed)
<img width="1291" height="488" alt="image" src="https://github.com/user-attachments/assets/4c61713d-0b72-41ec-b18c-c033df8a5283" />
